### PR TITLE
x-robots-tag除去

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -7,7 +7,6 @@ http://:8080 {
 
   header {
     Strict-Transport-Security "max-age=31536000;"
-    X-Robots-Tag "none"
   }
 
   handle /api* {


### PR DESCRIPTION
traPのCaddyfileからの名残で、x-robots-tagが設定されておりcrawlされなくなっていた。