### PR TITLE
poll cardのui崩れ修正

### DIFF
--- a/client/src/components/PollCard.vue
+++ b/client/src/components/PollCard.vue
@@ -19,7 +19,7 @@
           v-for="q in poll.question"
           :key="q.id"
           type="button"
-          class="vote-button btn btn-outline-secondary mb-1"
+          class="vote-button btn btn-outline-secondary mb-1 w-100"
           disabled>
           {{ q.choice }}
         </button>
@@ -29,7 +29,7 @@
           v-for="(q, i) in poll.question"
           :key="q.id"
           type="button"
-          class="vote-button btn btn-outline-secondary mb-1"
+          class="vote-button btn btn-outline-secondary mb-1 w-100"
           @click="submitPollID(i)">
           {{ q.choice }}
         </button>


### PR DESCRIPTION
結果未確定のpollのカードのUIが壊れていたため、修正した。
おそらくbootstrapのアップデート時に壊れたと思われる。
#### before
<img width="427" alt="image" src="https://github.com/user-attachments/assets/9200f401-e06b-444d-9625-92c8c9a865b7" />

#### after
<img width="374" alt="image" src="https://github.com/user-attachments/assets/f1cefb8d-78d5-4e2b-94bc-361c50e4d474" />
